### PR TITLE
[FIx] 오브젝트 풀링을 위한 몬스터 구조 변경

### DIFF
--- a/Medieval Slug/Assets/00.Scenes/Monster/MonsterTestScene.unity
+++ b/Medieval Slug/Assets/00.Scenes/Monster/MonsterTestScene.unity
@@ -1232,6 +1232,133 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 8314488c53996e944b2dbe6bf74a0fc7, type: 3}
+--- !u!4 &1225671376 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 5422235271331890033, guid: 8314488c53996e944b2dbe6bf74a0fc7, type: 3}
+  m_PrefabInstance: {fileID: 1225671375}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &1339182343
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1565117062265877348, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: <target>k__BackingField
+      value: 
+      objectReference: {fileID: 1225671376}
+    - target: {fileID: 3298963374946433179, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_Name
+      value: Eagle
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.25
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 5.9
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6745470527682787094, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: ee790ea1f852a4e47ad6c7b2e4666ee7, type: 3}
+--- !u!1001 &1539728081
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1522214104785138172, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_Name
+      value: Slime
+      objectReference: {fileID: 0}
+    - target: {fileID: 5510620291520525985, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: <target>k__BackingField
+      value: 
+      objectReference: {fileID: 1225671376}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9056047054283940948, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bb28427d232e55a47bddf2fc4321b32f, type: 3}
 --- !u!114 &1553472862 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 2569607620075104338, guid: d4ab664d38646ec489855fe677177641, type: 3}
@@ -1670,6 +1797,67 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 277af9d22a9a741439b7587607ef0a14, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!1001 &2028902815
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1532668442158802693, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_Name
+      value: RangedSlime
+      objectReference: {fileID: 0}
+    - target: {fileID: 5022226975820919478, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: <target>k__BackingField
+      value: 
+      objectReference: {fileID: 1225671376}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 2.4
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6113791106103305096, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 776ff647aa48b0844b751c2dd18ecc6f, type: 3}
 --- !u!1 &2054228127
 GameObject:
   m_ObjectHideFlags: 0
@@ -1815,10 +2003,6 @@ PrefabInstance:
       propertyPath: m_Name
       value: Dino
       objectReference: {fileID: 0}
-    - target: {fileID: 647741398944936912, guid: a6808bb25c7aac04b9fe286800954b2e, type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 6675960900695027463, guid: a6808bb25c7aac04b9fe286800954b2e, type: 3}
       propertyPath: m_LocalPosition.x
       value: 0
@@ -1859,6 +2043,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 9039928103637061360, guid: a6808bb25c7aac04b9fe286800954b2e, type: 3}
+      propertyPath: <target>k__BackingField
+      value: 
+      objectReference: {fileID: 1225671376}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1875,10 +2063,6 @@ PrefabInstance:
     - target: {fileID: 3933116385781919578, guid: df57abed95b0c4c4a8378e3372c6b307, type: 3}
       propertyPath: m_Name
       value: Bat
-      objectReference: {fileID: 0}
-    - target: {fileID: 3933116385781919578, guid: df57abed95b0c4c4a8378e3372c6b307, type: 3}
-      propertyPath: m_IsActive
-      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4071119206352260005, guid: df57abed95b0c4c4a8378e3372c6b307, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1920,6 +2104,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5582616241255311045, guid: df57abed95b0c4c4a8378e3372c6b307, type: 3}
+      propertyPath: <target>k__BackingField
+      value: 
+      objectReference: {fileID: 1225671376}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1936,6 +2124,10 @@ PrefabInstance:
     - target: {fileID: 4217685978182533801, guid: d4ab664d38646ec489855fe677177641, type: 3}
       propertyPath: m_Name
       value: BossTurret
+      objectReference: {fileID: 0}
+    - target: {fileID: 4217685978182533801, guid: d4ab664d38646ec489855fe677177641, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8084538234769640650, guid: d4ab664d38646ec489855fe677177641, type: 3}
       propertyPath: m_LocalPosition.x
@@ -1988,10 +2180,13 @@ SceneRoots:
   m_Roots:
   - {fileID: 1605129393}
   - {fileID: 5932547836677674746}
-  - {fileID: 3411404995057807356}
-  - {fileID: 117494225461799966}
   - {fileID: 696062127}
   - {fileID: 1645144225}
   - {fileID: 1225671375}
   - {fileID: 40846198}
   - {fileID: 483417947}
+  - {fileID: 1539728081}
+  - {fileID: 1339182343}
+  - {fileID: 2028902815}
+  - {fileID: 117494225461799966}
+  - {fileID: 3411404995057807356}

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/FlyingMonster/FlyingMonsterAttackState.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/FlyingMonster/FlyingMonsterAttackState.cs
@@ -24,7 +24,7 @@ public class FlyingMonsterAttackState : MonsterBaseState
         originalPosition = StateMachine.Monster.transform.position;
         attackTargetPosition = StateMachine.target.position;
         
-        FlyingStateMachine.MeleeMonster.EnableCollider();
+        FlyingStateMachine.MeleeMonster.MeleeCollider.EnableCollider();
         
         if (StateMachine.Monster.HasAnimator) 
             StartAnimation(StateMachine.Monster.AnimationHash.AttackParameterHash);
@@ -40,7 +40,7 @@ public class FlyingMonsterAttackState : MonsterBaseState
         }
         else if (!isReturning && IsReachedPlayer())
         {
-            FlyingStateMachine.MeleeMonster.DisableCollider();
+            FlyingStateMachine.MeleeMonster.MeleeCollider.DisableCollider();
             isReturning = true;
             
             if (StateMachine.Monster.HasAnimator) 

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MeleeMonster.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MeleeMonster.cs
@@ -1,43 +1,22 @@
 using UnityEngine;
 
-[RequireComponent(typeof(BoxCollider2D))]
 public class MeleeMonster : Monster
 {
-    [field : Header("Melee Monster")]
-    private new Collider2D collider2D;
-    
+    [field: Header("Melee Monster")] 
+    [field: SerializeField] public MonsterMeleeAttack MeleeCollider { get; private set; }
+
+    protected override void Reset()
+    {
+        base.Reset();
+        MeleeCollider = GetComponentInChildren<MonsterMeleeAttack>();
+    }
 
     protected override void Awake()
     {
         base.Awake();
-        if (collider2D == null)
-        {
-            collider2D = GetComponent<Collider2D>();
-            if (collider2D == null)
-            {
-                collider2D = gameObject.AddComponent<BoxCollider2D>();
-            }
+        if (MeleeCollider == null)
+        { 
+            MeleeCollider = GetComponentInChildren<MonsterMeleeAttack>();
         }
-        DisableCollider();
-    }
-
-    public void EnableCollider()
-    {
-        collider2D.enabled = true;
-    }
-
-    public void DisableCollider()
-    {
-        collider2D.enabled = false;
-    }
-
-    private void OnTriggerEnter2D(Collider2D other)
-    {
-        if (!other.CompareTag("Player")) return;
-        other.TryGetComponent(out IDamagable damagable);
-        if(damagable != null) 
-            damagable.TakeDamage(MonsterData.Damage);
-        else
-            Debug.LogError($"{other.name}의 IDamagable을 찾을 수 없습니다.");
     }
 }

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MonsterMeleeAttack.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MonsterMeleeAttack.cs
@@ -1,0 +1,55 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MonsterMeleeAttack : MonoBehaviour
+{
+    [Header("Melee Monster")]
+    [SerializeField] private Monster monster;
+    [SerializeField] private new Collider2D collider2D;
+
+    private void Reset()
+    {
+        monster = transform.parent.GetComponent<Monster>();
+        collider2D = GetComponent<Collider2D>();
+    }
+
+    protected void Awake()
+    {
+        if (monster == null)
+        {
+            monster = transform.parent.GetComponent<Monster>();
+        }
+        if (collider2D == null)
+        {
+            collider2D = GetComponent<Collider2D>();
+        }
+        DisableCollider();
+    }
+
+    public void EnableCollider()
+    {
+        collider2D.enabled = true;
+    }
+
+    public void DisableCollider()
+    {
+        collider2D.enabled = false;
+    }
+
+    private void OnTriggerEnter2D(Collider2D other)
+    {
+        if (!other.CompareTag("Player")) return;
+        other.TryGetComponent(out IDamagable damagable);
+        if(damagable != null) 
+            damagable.TakeDamage(monster.MonsterData.Damage);
+        else
+            Debug.LogError($"{other.name}의 IDamagable을 찾을 수 없습니다.");
+    }
+
+    public void OnDespawn() 
+    {
+        monster.OnDespawn();
+    }
+}

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MonsterMeleeAttack.cs.meta
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/MeleeMonster/MonsterMeleeAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: df56b793f3cd8db47854a6456d2d0b41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/Monster.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/Monster.cs
@@ -3,8 +3,6 @@ using System.Collections;
 using UnityEngine;
 using Random = System.Random;
 
-[RequireComponent(typeof(SpriteRenderer))]
-[RequireComponent(typeof(Animator))]
 public class Monster : MonoBehaviour, IDamagable, IPoolable
 {
     [field: SerializeField] public Animator Animator { get; private set; }
@@ -25,16 +23,30 @@ public class Monster : MonoBehaviour, IDamagable, IPoolable
 
     protected virtual void Reset()
     {
-        Animator = GetComponent<Animator>();
+        Animator = GetComponentInChildren<Animator>();
 
         if (Animator != null)
             HasAnimator = true;
 
-        stateMachine = transform.parent.GetComponent<MonsterStateMachine>();
+        stateMachine = GetComponent<MonsterStateMachine>();
     }
 
     protected virtual void Awake()
     {
+        if (Animator == null)
+        {
+            Animator = GetComponentInChildren<Animator>();
+            if (Animator != null)
+            {
+                HasAnimator = true;
+            }
+        }
+
+        if (stateMachine == null)
+        {
+            stateMachine = GetComponent<MonsterStateMachine>();
+        }
+        
         Initialize();
     }
 

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/MonsterRangedAttack.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/MonsterRangedAttack.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MonsterRangedAttack : MonoBehaviour
+{
+    [SerializeField] private Monster monster;
+    [SerializeField] private Transform ShootPoint;
+    [SerializeField] private Vector2 dir;
+
+    protected void Reset()
+    {
+        monster = transform.parent.GetComponent<Monster>();
+        ShootPoint = transform.Find("ShootPoint").transform;
+    }
+
+    protected void Awake()
+    {
+        if (monster == null)
+        {
+            monster = transform.parent.GetComponent<Monster>();
+        }
+        if (ShootPoint == null)
+        {
+            ShootPoint = transform.Find("ShootPoint").transform;
+        }
+        float dirX = ShootPoint.transform.position.x - transform.position.x;
+        dir = new Vector2(dirX, 0).normalized;
+    }
+
+    public void RangedAttack()
+    {
+        float rot = Mathf.Abs(transform.rotation.eulerAngles.y);
+        if (rot >= 180)
+        { 
+            ProjectileManager.Instance.Shoot(-dir, ShootPoint, ProjectileType.Slime);
+        }
+        else
+        {
+            ProjectileManager.Instance.Shoot(dir, ShootPoint, ProjectileType.Slime);
+        }
+    }
+
+    public void OnDespawn() 
+    {
+        monster.OnDespawn();
+    }
+}

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/MonsterRangedAttack.cs.meta
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/MonsterRangedAttack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8012140c1cb3426429a1c764782a4a9f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/RangedMonster.cs
+++ b/Medieval Slug/Assets/01.Scripts/Entities/Enemy/RangedMonster/RangedMonster.cs
@@ -2,32 +2,21 @@ using UnityEngine;
 
 public class RangedMonster : Monster
 {
-    [SerializeField] private Transform ShootPoint;
-    [SerializeField] private Vector2 dir;
+    [field: Header("Ranged Monster")]
+    [field: SerializeField] public MonsterRangedAttack RangedAttack { get; private set; }
 
     protected override void Reset()
     {
         base.Reset();
-        ShootPoint = transform.Find("ShootPoint").transform;
+        RangedAttack = GetComponentInChildren<MonsterRangedAttack>();
     }
 
     protected override void Awake()
     {
         base.Awake();
-        float dirX = ShootPoint.transform.position.x - transform.position.x;
-        dir = new Vector2(dirX, 0).normalized;
-    }
-
-    public void RangedAttack()
-    {
-        float rot = Mathf.Abs(transform.rotation.eulerAngles.y);
-        if (rot >= 180)
-        { 
-            ProjectileManager.Instance.Shoot(-dir, ShootPoint, ProjectileType.Slime);
-        }
-        else
+        if (RangedAttack == null)
         {
-            ProjectileManager.Instance.Shoot(dir, ShootPoint, ProjectileType.Slime);
+            RangedAttack = GetComponentInChildren<MonsterRangedAttack>();
         }
     }
 }

--- a/Medieval Slug/Assets/02.Prefabs/Monster/Bat.prefab
+++ b/Medieval Slug/Assets/02.Prefabs/Monster/Bat.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 5829924321147921000}
   - component: {fileID: 8228489494600492931}
   - component: {fileID: 4873144319710422286}
-  - component: {fileID: 7672239689431378346}
+  - component: {fileID: 7654231500111481215}
   m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
@@ -153,7 +153,7 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 3, y: 3}
   m_EdgeRadius: 0
---- !u!114 &7672239689431378346
+--- !u!114 &7654231500111481215
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -162,26 +162,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 2853359684138835707}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
+  m_Script: {fileID: 11500000, guid: df56b793f3cd8db47854a6456d2d0b41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Animator>k__BackingField: {fileID: 5829924321147921000}
-  <AnimationHash>k__BackingField:
-    idleParameterName: Idle
-    runParameterName: Run
-    attackParameterName: Attack
-    deadParameterName: Dead
-    hitParameterName: Hit
-    halfHealthParameterName: HalfHealth
-    appearingParameterName: Appearing
-    defeatParameterName: Defeat
-    attackTriggerParameterName: AttackTrigger
-    randomDropTriggerParameterName: RandomDropTrigger
-  <HasAnimator>k__BackingField: 1
-  stateMachine: {fileID: 5582616241255311045}
-  <MonsterData>k__BackingField: {fileID: 11400000, guid: b5e4eb0b150b07c4fb5863aa4883cb25, type: 2}
-  health: 0
-  speed: 0
+  monster: {fileID: 3417120768794554956}
+  collider2D: {fileID: 4873144319710422286}
 --- !u!1 &3933116385781919578
 GameObject:
   m_ObjectHideFlags: 0
@@ -194,7 +179,7 @@ GameObject:
   - component: {fileID: 3137839742351185098}
   - component: {fileID: 2369755699082370906}
   - component: {fileID: 5582616241255311045}
-  - component: {fileID: 108087209811867163}
+  - component: {fileID: 3417120768794554956}
   m_Layer: 7
   m_Name: Bat
   m_TagString: Untagged
@@ -302,12 +287,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcf5ac662e464cfabe4c50d88632aeb6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Monster>k__BackingField: {fileID: 7672239689431378346}
+  <Monster>k__BackingField: {fileID: 3417120768794554956}
   <target>k__BackingField: {fileID: 0}
   <targetLayer>k__BackingField:
     serializedVersion: 2
     m_Bits: 64
---- !u!114 &108087209811867163
+--- !u!114 &3417120768794554956
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -316,7 +301,24 @@ MonoBehaviour:
   m_GameObject: {fileID: 3933116385781919578}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80f8b7c7fef4ae54bad1f586e871ffde, type: 3}
+  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monster: {fileID: 7672239689431378346}
+  <Animator>k__BackingField: {fileID: 5829924321147921000}
+  <AnimationHash>k__BackingField:
+    idleParameterName: Idle
+    runParameterName: Run
+    attackParameterName: Attack
+    deadParameterName: Dead
+    hitParameterName: Hit
+    halfHealthParameterName: HalfHealth
+    appearingParameterName: Appearing
+    defeatParameterName: Defeat
+    attackTriggerParameterName: AttackTrigger
+    randomDropTriggerParameterName: RandomDropTrigger
+  <HasAnimator>k__BackingField: 1
+  stateMachine: {fileID: 5582616241255311045}
+  <MonsterData>k__BackingField: {fileID: 11400000, guid: b5e4eb0b150b07c4fb5863aa4883cb25, type: 2}
+  health: 0
+  speed: 0
+  <MeleeCollider>k__BackingField: {fileID: 7654231500111481215}

--- a/Medieval Slug/Assets/02.Prefabs/Monster/Dino.prefab
+++ b/Medieval Slug/Assets/02.Prefabs/Monster/Dino.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 7324019708429740425}
   - component: {fileID: 3064102280652134474}
   - component: {fileID: 9039928103637061360}
-  - component: {fileID: 8204893321508326200}
+  - component: {fileID: 5715090810260234931}
   m_Layer: 7
   m_Name: Dino
   m_TagString: Untagged
@@ -120,12 +120,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c614a452d58ca498722f5dc02d17cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Monster>k__BackingField: {fileID: 3142318813882849483}
+  <Monster>k__BackingField: {fileID: 5715090810260234931}
   <target>k__BackingField: {fileID: 0}
   <targetLayer>k__BackingField:
     serializedVersion: 2
     m_Bits: 64
---- !u!114 &8204893321508326200
+--- !u!114 &5715090810260234931
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -134,10 +134,27 @@ MonoBehaviour:
   m_GameObject: {fileID: 647741398944936912}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80f8b7c7fef4ae54bad1f586e871ffde, type: 3}
+  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monster: {fileID: 3142318813882849483}
+  <Animator>k__BackingField: {fileID: 7574959178625307334}
+  <AnimationHash>k__BackingField:
+    idleParameterName: Idle
+    runParameterName: Run
+    attackParameterName: Attack
+    deadParameterName: Dead
+    hitParameterName: Hit
+    halfHealthParameterName: HalfHealth
+    appearingParameterName: Appearing
+    defeatParameterName: Defeat
+    attackTriggerParameterName: AttackTrigger
+    randomDropTriggerParameterName: RandomDropTrigger
+  <HasAnimator>k__BackingField: 1
+  stateMachine: {fileID: 9039928103637061360}
+  <MonsterData>k__BackingField: {fileID: 11400000, guid: 2e06fe5f59310b04b8466d4b97ec4e04, type: 2}
+  health: 0
+  speed: 0
+  <MeleeCollider>k__BackingField: {fileID: 749497983422485210}
 --- !u!1 &8639093172223346037
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,7 +167,7 @@ GameObject:
   - component: {fileID: 7574959178625307334}
   - component: {fileID: 4520211376287996948}
   - component: {fileID: 2671001001177396932}
-  - component: {fileID: 3142318813882849483}
+  - component: {fileID: 749497983422485210}
   m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
@@ -291,7 +308,7 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.45376396, y: 1.25}
   m_EdgeRadius: 0
---- !u!114 &3142318813882849483
+--- !u!114 &749497983422485210
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -300,23 +317,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 8639093172223346037}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
+  m_Script: {fileID: 11500000, guid: df56b793f3cd8db47854a6456d2d0b41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Animator>k__BackingField: {fileID: 7574959178625307334}
-  <AnimationHash>k__BackingField:
-    idleParameterName: Idle
-    runParameterName: Run
-    attackParameterName: Attack
-    deadParameterName: Dead
-    hitParameterName: Hit
-    halfHealthParameterName: HalfHealth
-    appearingParameterName: Appearing
-    defeatParameterName: Defeat
-    attackTriggerParameterName: AttackTrigger
-    randomDropTriggerParameterName: RandomDropTrigger
-  <HasAnimator>k__BackingField: 1
-  stateMachine: {fileID: 9039928103637061360}
-  <MonsterData>k__BackingField: {fileID: 11400000, guid: 2e06fe5f59310b04b8466d4b97ec4e04, type: 2}
-  health: 0
-  speed: 0
+  monster: {fileID: 5715090810260234931}
+  collider2D: {fileID: 2671001001177396932}

--- a/Medieval Slug/Assets/02.Prefabs/Monster/Eagle.prefab
+++ b/Medieval Slug/Assets/02.Prefabs/Monster/Eagle.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6551657610800734788}
   - component: {fileID: 633921220804297656}
   - component: {fileID: 1565117062265877348}
-  - component: {fileID: 6670951016732344379}
+  - component: {fileID: 2158622018464628264}
   m_Layer: 7
   m_Name: Eagle
   m_TagString: Untagged
@@ -120,12 +120,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: fcf5ac662e464cfabe4c50d88632aeb6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Monster>k__BackingField: {fileID: 7739054415713413132}
+  <Monster>k__BackingField: {fileID: 2158622018464628264}
   <target>k__BackingField: {fileID: 0}
   <targetLayer>k__BackingField:
     serializedVersion: 2
     m_Bits: 64
---- !u!114 &6670951016732344379
+--- !u!114 &2158622018464628264
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -134,10 +134,27 @@ MonoBehaviour:
   m_GameObject: {fileID: 3298963374946433179}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80f8b7c7fef4ae54bad1f586e871ffde, type: 3}
+  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monster: {fileID: 7739054415713413132}
+  <Animator>k__BackingField: {fileID: 5852529761388961873}
+  <AnimationHash>k__BackingField:
+    idleParameterName: Idle
+    runParameterName: Run
+    attackParameterName: Attack
+    deadParameterName: Dead
+    hitParameterName: Hit
+    halfHealthParameterName: HalfHealth
+    appearingParameterName: Appearing
+    defeatParameterName: Defeat
+    attackTriggerParameterName: AttackTrigger
+    randomDropTriggerParameterName: RandomDropTrigger
+  <HasAnimator>k__BackingField: 1
+  stateMachine: {fileID: 1565117062265877348}
+  <MonsterData>k__BackingField: {fileID: 11400000, guid: 32b1a67415c800b40923d5b9c46f57f2, type: 2}
+  health: 0
+  speed: 0
+  <MeleeCollider>k__BackingField: {fileID: 8865103176045662107}
 --- !u!1 &8120944490431652483
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,7 +167,7 @@ GameObject:
   - component: {fileID: 5852529761388961873}
   - component: {fileID: 1054298961499179622}
   - component: {fileID: 6662276762921072029}
-  - component: {fileID: 7739054415713413132}
+  - component: {fileID: 8865103176045662107}
   m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
@@ -291,7 +308,7 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 2.5, y: 2.5}
   m_EdgeRadius: 0
---- !u!114 &7739054415713413132
+--- !u!114 &8865103176045662107
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -300,23 +317,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 8120944490431652483}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
+  m_Script: {fileID: 11500000, guid: df56b793f3cd8db47854a6456d2d0b41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Animator>k__BackingField: {fileID: 5852529761388961873}
-  <AnimationHash>k__BackingField:
-    idleParameterName: Idle
-    runParameterName: Run
-    attackParameterName: Attack
-    deadParameterName: Dead
-    hitParameterName: Hit
-    halfHealthParameterName: HalfHealth
-    appearingParameterName: Appearing
-    defeatParameterName: Defeat
-    attackTriggerParameterName: AttackTrigger
-    randomDropTriggerParameterName: RandomDropTrigger
-  <HasAnimator>k__BackingField: 1
-  stateMachine: {fileID: 1565117062265877348}
-  <MonsterData>k__BackingField: {fileID: 11400000, guid: 32b1a67415c800b40923d5b9c46f57f2, type: 2}
-  health: 0
-  speed: 0
+  monster: {fileID: 2158622018464628264}
+  collider2D: {fileID: 6662276762921072029}

--- a/Medieval Slug/Assets/02.Prefabs/Monster/RangedSlime.prefab
+++ b/Medieval Slug/Assets/02.Prefabs/Monster/RangedSlime.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 6506889081947878118}
   - component: {fileID: 3635027562237109546}
   - component: {fileID: 5022226975820919478}
-  - component: {fileID: 1137154634029975480}
+  - component: {fileID: 4958855196337466752}
   m_Layer: 7
   m_Name: RangedSlime
   m_TagString: Untagged
@@ -120,12 +120,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c614a452d58ca498722f5dc02d17cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Monster>k__BackingField: {fileID: 4126754008536790119}
+  <Monster>k__BackingField: {fileID: 4958855196337466752}
   <target>k__BackingField: {fileID: 0}
   <targetLayer>k__BackingField:
     serializedVersion: 2
     m_Bits: 64
---- !u!114 &1137154634029975480
+--- !u!114 &4958855196337466752
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -134,10 +134,27 @@ MonoBehaviour:
   m_GameObject: {fileID: 1532668442158802693}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80f8b7c7fef4ae54bad1f586e871ffde, type: 3}
+  m_Script: {fileID: 11500000, guid: 5a448723331f4c54be57bc6a6128d333, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monster: {fileID: 4126754008536790119}
+  <Animator>k__BackingField: {fileID: 9106230449813526663}
+  <AnimationHash>k__BackingField:
+    idleParameterName: Idle
+    runParameterName: Run
+    attackParameterName: Attack
+    deadParameterName: Dead
+    hitParameterName: Hit
+    halfHealthParameterName: HalfHealth
+    appearingParameterName: Appearing
+    defeatParameterName: Defeat
+    attackTriggerParameterName: AttackTrigger
+    randomDropTriggerParameterName: RandomDropTrigger
+  <HasAnimator>k__BackingField: 1
+  stateMachine: {fileID: 5022226975820919478}
+  <MonsterData>k__BackingField: {fileID: 11400000, guid: 45cdc68fb4764c640b68deb01ef425d2, type: 2}
+  health: 0
+  speed: 0
+  <RangedAttack>k__BackingField: {fileID: 442417525670263014}
 --- !u!1 &3115860598697341014
 GameObject:
   m_ObjectHideFlags: 0
@@ -162,8 +179,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3115860598697341014}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -0.5, y: 0.6, z: 0}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.49999988, y: 0.5999999, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -180,7 +197,7 @@ GameObject:
   - component: {fileID: 4690290662441989814}
   - component: {fileID: 9106230449813526663}
   - component: {fileID: 1730311566386582147}
-  - component: {fileID: 4126754008536790119}
+  - component: {fileID: 442417525670263014}
   m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
@@ -277,7 +294,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 1
---- !u!114 &4126754008536790119
+--- !u!114 &442417525670263014
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -286,25 +303,9 @@ MonoBehaviour:
   m_GameObject: {fileID: 5155684518470781678}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5a448723331f4c54be57bc6a6128d333, type: 3}
+  m_Script: {fileID: 11500000, guid: 8012140c1cb3426429a1c764782a4a9f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Animator>k__BackingField: {fileID: 9106230449813526663}
-  <AnimationHash>k__BackingField:
-    idleParameterName: Idle
-    runParameterName: Run
-    attackParameterName: Attack
-    deadParameterName: Dead
-    hitParameterName: Hit
-    halfHealthParameterName: HalfHealth
-    appearingParameterName: Appearing
-    defeatParameterName: Defeat
-    attackTriggerParameterName: AttackTrigger
-    randomDropTriggerParameterName: RandomDropTrigger
-  <HasAnimator>k__BackingField: 1
-  stateMachine: {fileID: 5022226975820919478}
-  <MonsterData>k__BackingField: {fileID: 11400000, guid: 45cdc68fb4764c640b68deb01ef425d2, type: 2}
-  health: 0
-  speed: 0
+  monster: {fileID: 4958855196337466752}
   ShootPoint: {fileID: 3898489102591094056}
   dir: {x: 0, y: 0}

--- a/Medieval Slug/Assets/02.Prefabs/Monster/Slime.prefab
+++ b/Medieval Slug/Assets/02.Prefabs/Monster/Slime.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 8163179160973770422}
   - component: {fileID: 6799457534693210753}
   - component: {fileID: 5510620291520525985}
-  - component: {fileID: 8446945495472101911}
+  - component: {fileID: 5150746925184293626}
   m_Layer: 7
   m_Name: Slime
   m_TagString: Untagged
@@ -120,12 +120,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 60c614a452d58ca498722f5dc02d17cf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Monster>k__BackingField: {fileID: 1301285300495454382}
+  <Monster>k__BackingField: {fileID: 5150746925184293626}
   <target>k__BackingField: {fileID: 0}
   <targetLayer>k__BackingField:
     serializedVersion: 2
     m_Bits: 64
---- !u!114 &8446945495472101911
+--- !u!114 &5150746925184293626
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -134,10 +134,27 @@ MonoBehaviour:
   m_GameObject: {fileID: 1522214104785138172}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 80f8b7c7fef4ae54bad1f586e871ffde, type: 3}
+  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  monster: {fileID: 1301285300495454382}
+  <Animator>k__BackingField: {fileID: 3527447057664856588}
+  <AnimationHash>k__BackingField:
+    idleParameterName: Idle
+    runParameterName: Run
+    attackParameterName: Attack
+    deadParameterName: Dead
+    hitParameterName: Hit
+    halfHealthParameterName: HalfHealth
+    appearingParameterName: Appearing
+    defeatParameterName: Defeat
+    attackTriggerParameterName: AttackTrigger
+    randomDropTriggerParameterName: RandomDropTrigger
+  <HasAnimator>k__BackingField: 1
+  stateMachine: {fileID: 5510620291520525985}
+  <MonsterData>k__BackingField: {fileID: 11400000, guid: 5d983d5473ee4d349be0710859bc58e7, type: 2}
+  health: 0
+  speed: 0
+  <MeleeCollider>k__BackingField: {fileID: 8804629628678753413}
 --- !u!1 &3504495294394464896
 GameObject:
   m_ObjectHideFlags: 0
@@ -150,7 +167,7 @@ GameObject:
   - component: {fileID: 3527447057664856588}
   - component: {fileID: 8604316065426993281}
   - component: {fileID: 2738684958390053259}
-  - component: {fileID: 1301285300495454382}
+  - component: {fileID: 8804629628678753413}
   m_Layer: 7
   m_Name: Sprite
   m_TagString: Untagged
@@ -291,7 +308,7 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 0.5, y: 1.25}
   m_EdgeRadius: 0
---- !u!114 &1301285300495454382
+--- !u!114 &8804629628678753413
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -300,23 +317,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 3504495294394464896}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ef33b99e45d364942b1c1b14f390273b, type: 3}
+  m_Script: {fileID: 11500000, guid: df56b793f3cd8db47854a6456d2d0b41, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  <Animator>k__BackingField: {fileID: 3527447057664856588}
-  <AnimationHash>k__BackingField:
-    idleParameterName: Idle
-    runParameterName: Run
-    attackParameterName: Attack
-    deadParameterName: Dead
-    hitParameterName: Hit
-    halfHealthParameterName: HalfHealth
-    appearingParameterName: Appearing
-    defeatParameterName: Defeat
-    attackTriggerParameterName: AttackTrigger
-    randomDropTriggerParameterName: RandomDropTrigger
-  <HasAnimator>k__BackingField: 1
-  stateMachine: {fileID: 5510620291520525985}
-  <MonsterData>k__BackingField: {fileID: 11400000, guid: 5d983d5473ee4d349be0710859bc58e7, type: 2}
-  health: 0
-  speed: 0
+  monster: {fileID: 5150746925184293626}
+  collider2D: {fileID: 2738684958390053259}

--- a/Medieval Slug/Assets/05.Arts/Animations/Monster/Bat/Bat_Dead.anim
+++ b/Medieval Slug/Assets/05.Arts/Animations/Monster/Bat/Bat_Dead.anim
@@ -278,7 +278,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0.33333334
-    functionName: DisableGameObject
+    functionName: OnDespawn
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0

--- a/Medieval Slug/Assets/05.Arts/Animations/Monster/Dino/Dino_Dead.anim
+++ b/Medieval Slug/Assets/05.Arts/Animations/Monster/Dino/Dino_Dead.anim
@@ -495,7 +495,7 @@ AnimationClip:
   m_HasMotionFloatCurves: 0
   m_Events:
   - time: 0.41666666
-    functionName: DisableGameObject
+    functionName: OnDespawn
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0


### PR DESCRIPTION
상위 : 스탯머신, 몬스터 데미지 핸들러를 포함한 오브젝트
ㄴ하위 : 애니메이터, 스프라이트, 몬스터(IDamagable, IPoolable)을 포함한 오브젝트

구조에서

상위 : 스탯머신, 몬스터(IDamagable, IPoolable)을 포함한 오브젝트
ㄴ하위 : 애니메이터, 스프라이트, 각 몬스터 종류별 공격로직 스크립트(MonsterMeleeAttack, MonsterRangedAttack)를 포함한 오브젝트

의 구조로 변경